### PR TITLE
Update radare2 to 5.8.4

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: radare2
-version: '5.8.2'
+version: '5.8.4'
 summary: UNIX-like reverse engineering framework and command-line toolset
 description: |
   r2 is a complete rewrite of radare. It provides a set of libraries, tools and
@@ -59,11 +59,7 @@ apps:
     command: usr/bin/rax2
 
 environment:
-  # R2_PREFIX: "$SNAP/usr" # Currently not parsed
-  # R2_LIBDIR: "$SNAP/usr/lib" # Currently not parsed
-  # R2_INCDIR: "$SNAP/usr/include/libr" # Currently not parsed
-  R2_LIBR_PLUGINS: "$SNAP/usr/lib/radare2/$SNAP_VERSION"
-  R2_MAGICPATH: "$SNAP/usr/share/radare2/$SNAP_VERSION/magic"
+  R2_PREFIX: "$SNAP/usr"
   SLEIGHHOME: "$SNAP/usr/lib/radare2/$SNAP_VERSION"
 
 architectures:
@@ -92,10 +88,6 @@ parts:
     autotools-configure-parameters:
       - --prefix=/usr
       - --with-checks-level=0
-    # This override will not be needed in radare version 5.8.3
-    override-build: |
-      craftctl default
-      sed -i 's,^libdir=.*,libdir=${prefix}/lib,' "$CRAFT_PART_INSTALL"/usr/lib/pkgconfig/*.pc
     prime:
       - -usr/include
       - -usr/lib/pkgconfig

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -107,7 +107,7 @@ parts:
     source: https://github.com/radareorg/r2ghidra.git
     source-type: git
     source-depth: 1
-    source-tag: $SNAPCRAFT_PROJECT_VERSION
+    source-tag: '5.8.2'
     build-attributes:
       - enable-patchelf
     build-environment:
@@ -127,7 +127,7 @@ parts:
     source: https://github.com/nowsecure/r2frida.git
     source-type: git
     source-depth: 1
-    source-tag: $SNAPCRAFT_PROJECT_VERSION
+    source-tag: '5.8.2'
     build-attributes:
       - enable-patchelf
     build-environment:


### PR DESCRIPTION
Update radare2 to 5.8.4.

Also removes the hack for pkgconfig files and updates the environment to use the new `R2_PREFIX` env var.